### PR TITLE
User.model.refactor

### DIFF
--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -3,22 +3,26 @@ defmodule Yggdrasil.UserTest do
 
   alias Yggdrasil.User
 
-  @valid_attrs %{username: "tester", password: "password", password_confirmation: "password"}
-  @valid_attrs_upcase_user %{username: "TESTER", password: "password", password_confirmation: "password"}
+  @min_len 4
+  @password "password"
+  @short_password String.slice(@password, 1..(@min_len - 1))
 
-  @missing_username %{password: "password", password_confirmation: "pass"}
-  @missing_password %{username: "tester", password_confirmation: "password"}
-  @missing_password_conf %{username: "tester", password: "password"}
-  @password_mismatch %{username: "tester", password: "test", password_confirmation: "tester"}
-  @password_bad_len %{username: "tester", password: "te", password_confirmation: "tester"}
-  @password_conf_bad_len %{username: "tester", password: "te", password_confirmation: "te"}
+  @valid_attrs %{username: "tester", password: @password, password_confirmation: @password }
+
+  @valid_attrs_upcase_user    Map.update!(@valid_attrs, :username, &String.upcase/1)
+  @missing_username           Map.drop(@valid_attrs, [:username])
+  @missing_password           Map.drop(@valid_attrs, [:password])
+  @missing_password_conf      Map.drop(@valid_attrs, [:password_confirmation])
+  @password_mismatch          %{@valid_attrs | :password => "not password"}
+  @password_bad_len           %{@valid_attrs | :password => @short_password}
+  @password_conf_bad_len      %{@valid_attrs | :password => @short_password,
+                                               :password_confirmation => @short_password}
 
   @blank_msg "can't be blank"
   @doesntmatch_msg "does not match confirmation"
   @unique_msg "has already been taken"
-
   @invalid_length_msg "should be at least %{count} character(s)"
-  @min_count 4
+
 
   test "create_changeset with valid attributes" do
     changeset = User.create_changeset(%User{}, @valid_attrs)
@@ -56,14 +60,14 @@ defmodule Yggdrasil.UserTest do
   test "create_changeset with password less than min fails" do
     changeset = User.create_changeset(%User{}, @password_bad_len)
 
-    assert changeset.errors[:password] == {@invalid_length_msg, [count: @min_count]}
+    assert changeset.errors[:password] == {@invalid_length_msg, [count: @min_len]}
     refute changeset.valid?
   end
 
   test "create_changeset with password_confirmation less than min fails" do
     changeset = User.create_changeset(%User{}, @password_conf_bad_len)
 
-    assert changeset.errors[:password_confirmation] == {@invalid_length_msg, [count: @min_count]}
+    assert changeset.errors[:password_confirmation] == {@invalid_length_msg, [count: @min_len]}
     refute changeset.valid?
   end
 
@@ -73,7 +77,7 @@ defmodule Yggdrasil.UserTest do
     {:ok, _user} = user |> Repo.insert
 
     # try again to invoke unique constraint
-    {error, changeset} = user |> Repo.insert
+    {:error, changeset} = user |> Repo.insert
     assert changeset.errors[:username] == @unique_msg
     refute changeset.valid?
   end

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -20,56 +20,56 @@ defmodule Yggdrasil.UserTest do
   @invalid_length_msg "should be at least %{count} character(s)"
   @min_count 4
 
-  test "changeset with valid attributes" do
-    changeset = User.changeset(%User{}, @valid_attrs)
+  test "create_changeset with valid attributes" do
+    changeset = User.create_changeset(%User{}, @valid_attrs)
     assert changeset.valid?
   end
 
-  test "changeset with missing username" do
-    changeset = User.changeset(%User{}, @missing_username)
+  test "create_changeset with missing username" do
+    changeset = User.create_changeset(%User{}, @missing_username)
 
     assert changeset.errors[:username] == @blank_msg
     refute changeset.valid?
   end
 
-  test "changeset with missing password" do
-    changeset = User.changeset(%User{}, @missing_password)
+  test "create_changeset with missing password" do
+    changeset = User.create_changeset(%User{}, @missing_password)
 
     assert changeset.errors[:password] == @blank_msg
     refute changeset.valid?
   end
 
-  test "changeset with missing password_confirmation" do
-    changeset = User.changeset(%User{}, @missing_password_conf)
+  test "create_changeset with missing password_confirmation" do
+    changeset = User.create_changeset(%User{}, @missing_password_conf)
 
     assert changeset.errors[:password_confirmation] == @blank_msg
     refute changeset.valid?
   end
 
-  test "changeset with password mismatch" do
-    changeset = User.changeset(%User{}, @password_mismatch)
+  test "create_changeset with password mismatch" do
+    changeset = User.create_changeset(%User{}, @password_mismatch)
 
     assert changeset.errors[:password_confirmation] == @doesntmatch_msg
     refute changeset.valid?
   end
 
-  test "changeset with password less than min fails" do
-    changeset = User.changeset(%User{}, @password_bad_len)
+  test "create_changeset with password less than min fails" do
+    changeset = User.create_changeset(%User{}, @password_bad_len)
 
     assert changeset.errors[:password] == {@invalid_length_msg, [count: @min_count]}
     refute changeset.valid?
   end
 
-  test "changeset with password_confirmation less than min fails" do
-    changeset = User.changeset(%User{}, @password_conf_bad_len)
+  test "create_changeset with password_confirmation less than min fails" do
+    changeset = User.create_changeset(%User{}, @password_conf_bad_len)
 
     assert changeset.errors[:password_confirmation] == {@invalid_length_msg, [count: @min_count]}
     refute changeset.valid?
   end
 
-  test "changeset unique username constraint" do
+  test "create_changeset unique username constraint" do
     # insert the user once
-    user = User.changeset(%User{}, @valid_attrs)
+    user = User.create_changeset(%User{}, @valid_attrs)
     {:ok, _user} = user |> Repo.insert
 
     # try again to invoke unique constraint
@@ -79,7 +79,7 @@ defmodule Yggdrasil.UserTest do
   end
 
   test "changset downcases username" do
-    user = User.changeset(%User{}, @valid_attrs_upcase_user)
+    user = User.create_changeset(%User{}, @valid_attrs_upcase_user)
 
     assert user.changes[:username] == "tester"
   end

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -2,6 +2,7 @@ defmodule Yggdrasil.UserTest do
   use Yggdrasil.ModelCase
 
   alias Yggdrasil.User
+  alias Comeonin.Bcrypt
 
   @min_len 4
   @password "password"
@@ -23,6 +24,17 @@ defmodule Yggdrasil.UserTest do
   @unique_msg "has already been taken"
   @invalid_length_msg "should be at least %{count} character(s)"
 
+  # -- helpers
+
+  defp valid_hash(hash) do
+    Bcrypt.checkpw(@password, hash)
+  end
+
+  defp hash_missing?(changeset) do
+    !Map.has_key?(changeset.changes, :hash)
+  end
+
+  # -- tests
 
   test "create_changeset with valid attributes" do
     changeset = User.create_changeset(%User{}, @valid_attrs)
@@ -82,9 +94,69 @@ defmodule Yggdrasil.UserTest do
     refute changeset.valid?
   end
 
-  test "changset downcases username" do
+  test "create_changeset downcases username" do
     user = User.create_changeset(%User{}, @valid_attrs_upcase_user)
 
     assert user.changes[:username] == "tester"
+  end
+
+  test "create_changet genreates hash if valid" do
+    changeset = User.create_changeset(%User{}, @valid_attrs)
+
+    assert Map.has_key?(changeset.changes, :hash)
+
+    hash = changeset.changes[:hash]
+    assert valid_hash(hash)
+  end
+
+  test "create_changet doesn't genreates hash if username missing" do
+    changeset = User.create_changeset(%User{}, @valid_attrs)
+
+    assert Map.has_key?(changeset.changes, :hash)
+
+    hash = changeset.changes[:hash]
+    assert valid_hash(hash)
+  end
+
+  test "create_changeset with missing username doesn't generate hash" do
+    changeset = User.create_changeset(%User{}, @missing_username)
+
+    refute changeset.valid?
+    assert hash_missing?(changeset)
+  end
+
+  test "create_changeset with missing password doesn't generate hash" do
+    changeset = User.create_changeset(%User{}, @missing_password)
+
+    refute changeset.valid?
+    assert hash_missing?(changeset)
+  end
+
+  test "create_changeset with missing password_confirmation doesn't generate hash" do
+    changeset = User.create_changeset(%User{}, @missing_password_conf)
+
+    refute changeset.valid?
+    assert hash_missing?(changeset)
+  end
+
+  test "create_changeset with password mismatch doesn't generate hash" do
+    changeset = User.create_changeset(%User{}, @password_mismatch)
+
+    refute changeset.valid?
+    assert hash_missing?(changeset)
+  end
+
+  test "create_changeset with password less than min doesn't generate hash" do
+    changeset = User.create_changeset(%User{}, @password_bad_len)
+
+    refute changeset.valid?
+    assert hash_missing?(changeset)
+  end
+
+  test "create_changeset with password_confirmation less than min doesn't generate hash" do
+    changeset = User.create_changeset(%User{}, @password_conf_bad_len)
+
+    refute changeset.valid?
+    assert hash_missing?(changeset)
   end
 end

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -97,7 +97,7 @@ defmodule Yggdrasil.UserTest do
   test "create_changeset downcases username" do
     user = User.create_changeset(%User{}, @valid_attrs_upcase_user)
 
-    assert user.changes[:username] == "tester"
+    assert user.changes.username == "tester"
   end
 
   test "create_changet genreates hash if valid" do
@@ -105,7 +105,7 @@ defmodule Yggdrasil.UserTest do
 
     assert Map.has_key?(changeset.changes, :hash)
 
-    hash = changeset.changes[:hash]
+    hash = changeset.changes.hash
     assert valid_hash(hash)
   end
 
@@ -114,7 +114,7 @@ defmodule Yggdrasil.UserTest do
 
     assert Map.has_key?(changeset.changes, :hash)
 
-    hash = changeset.changes[:hash]
+    hash = changeset.changes.hash
     assert valid_hash(hash)
   end
 

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -85,11 +85,11 @@ defmodule Yggdrasil.UserTest do
 
   test "create_changeset unique username constraint" do
     # insert the user once
-    user = User.create_changeset(%User{}, @valid_attrs)
-    {:ok, _user} = user |> Repo.insert
+    user_changeset = User.create_changeset(%User{}, @valid_attrs)
+    {:ok, _user} = Repo.insert(user_changeset)
 
     # try again to invoke unique constraint
-    {:error, changeset} = user |> Repo.insert
+    {:error, changeset} = Repo.insert(user_changeset)
     assert changeset.errors[:username] == @unique_msg
     refute changeset.valid?
   end

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -101,7 +101,7 @@ defmodule Yggdrasil.UserTest do
     assert user.changes.username == "tester"
   end
 
-  test "create_changet genreates hash if valid" do
+  test "create_changet generates hash if valid" do
     changeset = User.create_changeset(%User{}, @valid_attrs)
 
     assert Map.has_key?(changeset.changes, :hash)
@@ -110,7 +110,7 @@ defmodule Yggdrasil.UserTest do
     assert valid_hash(hash)
   end
 
-  test "create_changet doesn't genreates hash if username missing" do
+  test "create_changet doesn't generates hash if username missing" do
     changeset = User.create_changeset(%User{}, @valid_attrs)
 
     assert Map.has_key?(changeset.changes, :hash)

--- a/web/controllers/registration_controller.ex
+++ b/web/controllers/registration_controller.ex
@@ -14,7 +14,7 @@ defmodule Yggdrasil.RegistrationController do
   def create(conn, %{"user" => user_params}) do
     changeset = User.create_changeset(%User{}, user_params)
 
-    case changeset |> Repo.insert() do
+    case Repo.insert(changeset) do
       {:ok, new_user} -> 
         conn
           |> put_flash(:info, "Succesfully registered and logged in")

--- a/web/controllers/registration_controller.ex
+++ b/web/controllers/registration_controller.ex
@@ -1,9 +1,6 @@
 defmodule Yggdrasil.RegistrationController do
   use Yggdrasil.Web, :controller
 
-  import Ecto.Changeset, only: [put_change: 3]
-  import Comeonin.Bcrypt, only: [hashpwsalt: 1]
-
   alias Yggdrasil.User
 
   # if logged in, go straight to client
@@ -11,25 +8,20 @@ defmodule Yggdrasil.RegistrationController do
   plug :scrub_params, "user" when action in [:create]
 
   def new(conn, _params) do
-    changeset = User.changeset(%User{})
-    render conn, changeset: changeset
+    render conn, changeset: User.create_changeset(%User{})
   end
 
   def create(conn, %{"user" => user_params}) do
-    changeset = User.changeset(%User{}, user_params)
+    changeset = User.create_changeset(%User{}, user_params)
 
-    result = changeset
-      |> put_change(:hash, hashpwsalt(changeset.params["password"]))
-      |> Repo.insert
-
-    case result do 
+    case changeset |> Repo.insert() do
       {:ok, new_user} -> 
         conn
           |> put_flash(:info, "Succesfully registered and logged in")
           |> put_session(:current_user, new_user)
           |> redirect(to: client_path(conn, :index))
-      {:error, result_changeset} ->
-        render conn, "new.html", changeset: result_changeset
+      {:error, err_changeset} ->
+        render conn, "new.html", changeset: err_changeset
     end
   end
 end

--- a/web/controllers/session_controller.ex
+++ b/web/controllers/session_controller.ex
@@ -13,7 +13,7 @@ defmodule Yggdrasil.SessionController do
 
   # not sure why this can't be index...
   def new(conn, _params) do
-    render conn, changeset: User.changeset(%User{})
+    render conn, changeset: User.create_changeset(%User{})
   end
 
   def create(conn, %{"user" => user_params}) do
@@ -26,7 +26,7 @@ defmodule Yggdrasil.SessionController do
       :error ->
         conn
           |> put_flash(:error, "Invalid username or password")
-          |> render("new.html", changeset: User.changeset(%User{}))
+          |> render("new.html", changeset: User.create_changeset(%User{}))
     end
   end
 

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -1,6 +1,9 @@
 defmodule Yggdrasil.User do
   use Yggdrasil.Web, :model
 
+  import Comeonin.Bcrypt, only: [hashpwsalt: 1]
+  require Logger
+
   schema "users" do
     field :username, :string
     field :hash, :string
@@ -9,22 +12,61 @@ defmodule Yggdrasil.User do
     timestamps
   end
 
-  @required_fields ~w(username password password_confirmation)
-  @optional_fields ~w()
-
   @doc """
-  Creates a changeset based on the `model` and `params`.
-
-  If no params are provided, an invalid changeset is returned
-  with no validation performed.
+  create_changeset should be used when creating a new user it ensures
+  all the fields needed are there and valid and generates a password
   """
-  def changeset(model, params \\ :empty) do
+  def create_changeset(model, params \\ :empty) do
     model
-    |> cast(params, @required_fields, @optional_fields)
+    |> cast(params, ~w(username password password_confirmation), ~w())
     |> update_change(:username, &String.downcase/1)
     |> unique_constraint(:username)
     |> validate_length(:password, min: 4)
     |> validate_length(:password_confirmation, min: 4)
     |> validate_confirmation(:password)
+    |> add_password(params)
+  end
+
+  @doc """
+  update_pw_changeset shuld be used when updating a password for a user.
+  it will only change the password field and ensures that username and other
+  fields are not modified.
+  """
+  def update_pw_changeset(model, params \\ :empty) do
+    model
+    |> cast(params, ~w(password password_confirmation), ~w())
+    |> validate_length(:password, min: 4)
+    |> validate_length(:password_confirmation, min: 4)
+    |> validate_confirmation(:password)
+    |> add_password(params)
+  end
+
+  @doc """
+  update_changeset should be used for general updates it exlcudes the hash field
+  if you need to update the users password please use update_pw_changeset
+  """
+  def update_changeset(model, params \\ :empty) do
+    model
+    |> cast(params, ~w(username), ~w())
+    |> update_change(:username, &String.downcase/1)
+    |> unique_constraint(:username)
+  end
+
+  @doc """
+  wrapped this in function need to ensure password is not nil
+  this is still reached even if the other validations have failed
+  """
+  def add_password(changeset, :empty) do
+    changeset
+  end
+
+  def add_password(changeset, params) do
+    # simply just going to do this only if params[:password] is not nil
+    if !!params[:password] do
+      put_change(changeset, :hash, hashpwsalt(params[:password]))
+    else
+      #skip for now
+      changeset
+    end
   end
 end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -24,7 +24,7 @@ defmodule Yggdrasil.User do
     |> validate_length(:password, min: 4)
     |> validate_length(:password_confirmation, min: 4)
     |> validate_confirmation(:password)
-    |> add_password
+    |> hash_password
   end
 
   @doc """
@@ -38,7 +38,7 @@ defmodule Yggdrasil.User do
     |> validate_length(:password, min: 4)
     |> validate_length(:password_confirmation, min: 4)
     |> validate_confirmation(:password)
-    |> add_password
+    |> hash_password
   end
 
   @doc """
@@ -56,11 +56,11 @@ defmodule Yggdrasil.User do
   adds password at end of chain protects the hashpwsalt from seeing a nil value
   in the case of missing password field.
   """
-  def add_password(changeset = %{:valid? => false}) do
+  def hash_password(changeset = %{:valid? => false}) do
     changeset
   end
 
-  def add_password(changeset = %{:valid? => true}) do
+  def hash_password(changeset = %{:valid? => true}) do
     changeset
       |> put_change(:hash, hashpwsalt(changeset.params["password"]))
   end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -24,7 +24,7 @@ defmodule Yggdrasil.User do
     |> validate_length(:password, min: 4)
     |> validate_length(:password_confirmation, min: 4)
     |> validate_confirmation(:password)
-    |> add_password(params)
+    |> add_password
   end
 
   @doc """
@@ -38,7 +38,7 @@ defmodule Yggdrasil.User do
     |> validate_length(:password, min: 4)
     |> validate_length(:password_confirmation, min: 4)
     |> validate_confirmation(:password)
-    |> add_password(params)
+    |> add_password
   end
 
   @doc """
@@ -53,20 +53,15 @@ defmodule Yggdrasil.User do
   end
 
   @doc """
-  wrapped this in function need to ensure password is not nil
-  this is still reached even if the other validations have failed
+  adds password at end of chain protects the hashpwsalt from seeing a nil value
+  in the case of missing password field.
   """
-  def add_password(changeset, :empty) do
+  def add_password(changeset = %{:valid? => false}) do
     changeset
   end
 
-  def add_password(changeset, params) do
-    # simply just going to do this only if params[:password] is not nil
-    if !!params[:password] do
-      put_change(changeset, :hash, hashpwsalt(params[:password]))
-    else
-      #skip for now
-      changeset
-    end
+  def add_password(changeset = %{:valid? => true}) do
+    changeset
+      |> put_change(:hash, hashpwsalt(changeset.params["password"]))
   end
 end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -28,31 +28,6 @@ defmodule Yggdrasil.User do
   end
 
   @doc """
-  update_pw_changeset shuld be used when updating a password for a user.
-  it will only change the password field and ensures that username and other
-  fields are not modified.
-  """
-  def update_pw_changeset(model, params \\ :empty) do
-    model
-    |> cast(params, ~w(password password_confirmation), ~w())
-    |> validate_length(:password, min: 4)
-    |> validate_length(:password_confirmation, min: 4)
-    |> validate_confirmation(:password)
-    |> hash_password
-  end
-
-  @doc """
-  update_changeset should be used for general updates it exlcudes the hash field
-  if you need to update the users password please use update_pw_changeset
-  """
-  def update_changeset(model, params \\ :empty) do
-    model
-    |> cast(params, ~w(username), ~w())
-    |> update_change(:username, &String.downcase/1)
-    |> unique_constraint(:username)
-  end
-
-  @doc """
   adds password at end of chain protects the hashpwsalt from seeing a nil value
   in the case of missing password field.
   """


### PR DESCRIPTION
@copenhas I think this sorts out the user model. If could look it over.

I updated the current tests to use create_changeset, there needs to be a additional tests for the other two changesets added and hash being populated needs to be validated. I had one case when I was doing this where a record go inserted with an null password, I was not able to reproduce this here. I'm certain that was due to a crash in add_password where it nil was given as the password string for hashpwsalt, which seems to be fixed but I'd feel better adding tests to try to make it break.

Also you had a question about the render taking a changeset, that is needed even in the "new" routes, because of the templates.

Example in [registration/new.html.eex](https://github.com/voluspa/yggdrasil/blob/74e2b43cdfcde6df9b96a59367c791fbcb89a8a1/web/templates/registration/new.html.eex#L2)

Since it expects a change set on each render if you don't pass it in `def new(...)` it doesn't like this. Of course we can probably instrument this better and do we want but that's why the blogs had it there... I removed it that's how I figured it out - probably something we can look at in future commits. 
