### PR TITLE
bumping elixir version in travis, fixed a build warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: elixir
 elixir:
-  - 1.1.1
+  - 1.2.0
 otp_release:
   - 18.2
 addons:

--- a/web/models/session.ex
+++ b/web/models/session.ex
@@ -1,7 +1,7 @@
 defmodule Yggdrasil.Session do
   alias Yggdrasil.User
 
-  def login(%{"username" => nil}, repo) do
+  def login(%{"username" => nil}, _repo) do
     :error
   end
 


### PR DESCRIPTION
Warning, you'll need to run a `mix clean` after you upgrade Elixir to 1.2
