### PR TITLE
when a user joins show a welcome message

### DIFF
--- a/lib/yggdrasil.ex
+++ b/lib/yggdrasil.ex
@@ -13,6 +13,8 @@ defmodule Yggdrasil do
       supervisor(Yggdrasil.Repo, []),
       # Here you could define other workers and supervisors as children
       # worker(Yggdrasil.Worker, [arg1, arg2, arg3]),
+      supervisor(Yggdrasil.Player.Supervisor, []),
+      worker(Yggdrasil.Player.Registry, [])
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/lib/yggdrasil/message.ex
+++ b/lib/yggdrasil/message.ex
@@ -1,0 +1,29 @@
+defmodule Yggdrasil.Message do
+  defstruct type: :info, message: nil
+
+  alias Yggdrasil.Message
+
+  def error(:already_registered) do
+    %Message {
+      type: :error,
+      message: """
+        A client is already connected for this account.
+        This connection will be closed.
+        """
+    }
+  end
+
+  def info(text) when is_binary(text) do
+    %Message {
+      type: :info,
+      message: text
+    }
+  end
+
+  def command(text) when is_binary(text) do
+    %Message {
+      type: :command,
+      message: text
+    }
+  end
+end

--- a/lib/yggdrasil/player.ex
+++ b/lib/yggdrasil/player.ex
@@ -1,0 +1,56 @@
+defmodule Yggdrasil.Player do
+  use GenServer
+  alias Yggdrasil.Message
+  alias Yggdrasil.Player.Supervisor
+  alias Yggdrasil.Player.Registry
+
+  def start_link(user_id, owner_pid, push_msg) do
+    GenServer.start_link __MODULE__, [user_id, owner_pid, push_msg]
+  end
+
+  def join_game(user_id, owner_pid, push_msg) do
+    Supervisor.add_player user_id, [owner_pid, push_msg]
+  end
+
+  def run_cmd(user_id, cmd = %Message{type: :command}) do
+    player_pid = Registry.get_player user_id
+    GenServer.cast(player_pid, {:run_cmd, cmd})
+  end
+
+  def notify(user_id, msg = %Message{}) do
+    player_pid = Registry.get_player user_id
+    GenServer.cast(player_pid, {:notify, msg})
+  end
+
+
+  def init([user_id, channel_pid, push_msg]) do
+    case Registry.register_player(user_id, self) do
+      :ok ->
+        monitor_ref = Process.monitor channel_pid
+        push_msg.(Message.info("Welcome to the game"))
+        {:ok, %{
+          user: user_id,
+          channel: channel_pid,
+          monitor: monitor_ref,
+          push_msg: push_msg
+        }}
+      {:error, reason} ->
+        {:stop, reason}
+    end
+  end
+
+  def handle_cast({:run_cmd, cmd}, state) do
+    state.push_msg.(cmd)
+    {:noreply, state}
+  end
+
+  def handle_cast({:notify, msg}, state) do
+    state.push_msg.(msg)
+    {:noreply, state}
+  end
+
+  def handle_info({:DOWN, _ref, :process, _pid, _reason}, state) do
+    # channel exited, lets log out the player
+    {:stop, {:shutdown, :logout}, state}
+  end
+end

--- a/lib/yggdrasil/player/registry.ex
+++ b/lib/yggdrasil/player/registry.ex
@@ -1,0 +1,91 @@
+defmodule Yggdrasil.Player.Registry do
+  use GenServer
+
+  @registry_ets :player_registry_ets
+
+  def start_link() do
+    GenServer.start_link __MODULE__, [], name: __MODULE__
+  end
+
+  def register_player(user_id, player_pid) do
+    GenServer.call __MODULE__, {:register, user_id, player_pid}
+  end
+
+  def is_online(user_id, options \\ [])
+  def is_online(user_id, options) do
+    sync = Keyword.get(options, :sync, false)
+
+    if sync do
+        GenServer.call __MODULE__, {:is_online, user_id}
+    else
+        do_is_online user_id
+    end
+  end
+
+  def get_player(user_id, options \\ [])
+  def get_player(user_id, options) do
+    sync = Keyword.get(options, :sync, false)
+
+    if sync do
+        GenServer.call __MODULE__, {:get_player, user_id}
+    else
+        do_get_player user_id
+    end
+  end
+
+
+  def init([]) do
+    table_id = :ets.new @registry_ets, [:named_table, :set]
+    {:ok, %{
+      :table_id => table_id,
+      :mon2user => %{ }
+    }}
+  end
+
+  def handle_call({:register, user_id, player_pid}, _from, state) do
+    case :ets.lookup @registry_ets, user_id do
+      [] ->
+        :ets.insert @registry_ets, {user_id, player_pid}
+        monitor = Process.monitor player_pid
+        {:reply, :ok, add_mon2user(state, monitor, user_id)}
+      [_] ->
+        {:reply, {:error, :already_registered}, state}
+    end
+  end
+
+  def handle_call({:is_online, user_id}, _from, state) do
+    {:reply, do_is_online(user_id), state}
+  end
+
+  def handle_call({:get_player, user_id}, _from, state) do
+    {:reply, do_get_player(user_id), state}
+  end
+
+  def handle_info({:DOWN, monitor, :process, _pid, _reason}, state) do
+    :ets.delete @registry_ets, state.mon2user[monitor]
+    {:noreply, remove_mon2user(state, monitor)}
+  end
+
+
+  defp add_mon2user(state, monitor, user_id) do
+    %{ state | :mon2user => Map.put(state.mon2user, monitor, user_id)}
+  end
+
+  defp remove_mon2user(state, monitor) do
+    %{ state | :mon2user => Map.delete(state.mon2user, monitor)}
+  end
+
+  defp do_is_online(user_id) do
+    case do_get_player(user_id) do
+      nil -> false
+      _pid -> true
+    end
+  end
+
+  defp do_get_player(user_id) do
+    case :ets.lookup @registry_ets, user_id do
+      [] -> nil
+      [{^user_id, player_pid}] -> player_pid
+    end
+  end
+end

--- a/lib/yggdrasil/player/supervisor.ex
+++ b/lib/yggdrasil/player/supervisor.ex
@@ -1,0 +1,19 @@
+defmodule Yggdrasil.Player.Supervisor do
+  use Supervisor
+
+  def start_link() do
+    Supervisor.start_link __MODULE__, [], name: __MODULE__
+  end
+
+  def init([]) do
+    children = [
+      worker(Yggdrasil.Player, [], restart: :transient)
+    ]
+
+    supervise(children, strategy: :simple_one_for_one)
+  end
+
+  def add_player(user_id, args) do
+    Supervisor.start_child(__MODULE__, [user_id | args])
+  end
+end

--- a/test/channels/player_channel_test.exs
+++ b/test/channels/player_channel_test.exs
@@ -1,0 +1,44 @@
+defmodule PlayerChannelTest do
+  use Yggdrasil.ChannelCase
+  alias Yggdrasil.PlayerChannel
+  alias Yggdrasil.Message
+
+  test "it returns an auth error if the wrong user tries to connect" do
+    assert {:error, %{ error: "auth failure" }} = join_channel 1, "player:2"
+  end
+
+  test "it will join the player to the game when recieving a 'join_game'" do
+    user_id = 20
+
+    {:ok, _reply, socket} = join_channel user_id
+    ref = push(socket, "join_game")
+    assert_reply ref, :ok
+
+    assert Yggdrasil.Player.Registry.is_online(user_id, sync: true)
+  end
+
+  test "it notifies the player if another client issues a 'join_game'" do
+    user_id = 20
+
+    {:ok, _reply, socket1} = join_channel user_id
+
+    ref = push(socket1, "join_game")
+    assert_reply ref, :ok
+
+    # simulates a second client trying to join
+    Task.async fn ->
+      {:ok, _reply, socket2} = join_channel user_id
+      push(socket2, "join_game")
+    end
+
+    assert_push "event", %Message{message: "Another client has tried to connect"}
+  end
+
+  defp join_channel(user_id, topic \\ nil)
+  defp join_channel(user_id, topic) do
+    if topic == nil, do: topic = "player:#{user_id}"
+
+    socket(:nil, %{ user: user_id})
+    |> subscribe_and_join(PlayerChannel, topic)
+  end
+end

--- a/test/lib/yggdrasil/player/registry_test.exs
+++ b/test/lib/yggdrasil/player/registry_test.exs
@@ -1,0 +1,58 @@
+defmodule PlayerRegistryTests do
+  use ExUnit.Case, async: true
+  alias Yggdrasil.Player.Registry
+
+  test "it allows a player to registry as online" do
+    user_id = 10
+    assert :ok = Registry.register_player user_id, self
+  end
+
+  test "it knows if a player is online" do
+    user_id = 11
+    refute Registry.is_online user_id
+    assert :ok = Registry.register_player user_id, self
+    assert Registry.is_online user_id
+  end
+
+  test "it will not allow the same player to register twice" do
+    user_id = 12
+
+    assert :ok = Registry.register_player user_id, self
+
+    register_task = Task.async(fn ->
+      Registry.register_player user_id, self 
+    end)
+
+    assert {:error, :already_registered} = Task.await(register_task)
+  end
+
+  test "it knows when a player exits" do
+    user_id = 13
+
+    register_task = Task.async(fn ->
+      Registry.register_player user_id, self
+    end)
+
+    # verify player was registered successfully
+    # and make the task process exit
+    assert :ok = Task.await(register_task)
+
+    # we'll do this sync' so that the registry has a chance
+    # to handle the exit message from the task
+    refute Registry.is_online user_id, sync: true
+  end
+
+  test "it can return the pid for the user" do
+    user_id = 14
+    assert :ok = Registry.register_player user_id, self
+
+    pid = Registry.get_player user_id
+
+    assert is_pid(pid)
+  end
+
+  test "it returns the nil if the user is offline" do
+    user_id = 15
+    assert Registry.get_player(user_id) == nil
+  end
+end

--- a/test/lib/yggdrasil/player_test.exs
+++ b/test/lib/yggdrasil/player_test.exs
@@ -1,0 +1,27 @@
+defmodule PlayerTest do
+  use ExUnit.Case, async: false
+  alias Yggdrasil.Player
+  alias Yggdrasil.Player.Registry
+
+  test "it registers the user as online when it starts" do
+    user_id = 1
+    {:ok, _pid} = Player.start_link user_id, self, fn (msg) ->
+      msg
+    end
+
+    assert Registry.is_online user_id
+  end
+
+  test "it uses push_msg/1 to push a welcome message" do
+    user_id = 2
+
+    # using an agent to store messages
+    {:ok, agent} = Agent.start_link(fn -> [] end)
+
+    {:ok, _pid} = Player.start_link user_id, self, fn (msg) ->
+      Agent.update agent, fn (msgs) -> [msg | msgs] end
+    end
+
+    assert %{ message: "Welcome to the game" } = Agent.get(agent, fn ([msgs]) -> msgs end)
+  end
+end

--- a/web/channels/game_channel.ex
+++ b/web/channels/game_channel.ex
@@ -1,16 +1,8 @@
 defmodule Yggdrasil.GameChannel do
   use Yggdrasil.Web, :channel
 
-  require Logger
-
   def join("game:lobby", _message, socket) do
-    Logger.info "client connected"
-    {:ok, socket}
-  end
-
-  def handle_in("user_cmd", message, socket) do
-    Logger.info "client sent a message"
-    push socket, "event", message
-    {:noreply, socket}
+    socket = assign socket, :player_topic, "player:#{socket.assigns.user}"
+    {:ok, %{ topic: socket.assigns.player_topic }, socket}
   end
 end

--- a/web/channels/player_channel.ex
+++ b/web/channels/player_channel.ex
@@ -1,0 +1,40 @@
+defmodule Yggdrasil.PlayerChannel do
+  use Yggdrasil.Web, :channel
+  alias Yggdrasil.Player
+  alias Yggdrasil.Endpoint
+  alias Yggdrasil.Message
+  require Logger
+
+  def join("player:" <> user_id = topic, _message, socket) do
+    if socket.assigns.user == String.to_integer(user_id) do
+      socket = assign socket, :player_topic, topic
+      {:ok, socket}
+    else
+      {:error, %{ error: "auth failure"} }
+    end
+  end
+
+  def handle_in("join_game", _message, socket) do
+    user_id = socket.assigns.user
+    player_topic = socket.assigns.player_topic
+    push_msg = fn (payload) ->
+      Endpoint.broadcast! player_topic, "event", payload
+    end
+
+    case Player.join_game user_id, self, push_msg do
+      {:ok, _pid} ->
+        {:reply, :ok,  socket}
+      {:error, :already_registered} ->
+        Player.notify(user_id,
+          Message.info("Another client has tried to connect"))
+
+        push socket, "event", Message.error(:already_registered)
+        {:stop, {:shutdown, :player_online}, socket}
+    end
+  end
+
+  def handle_in("player_cmd", %{ "text" => text }, socket) do
+    Player.run_cmd(socket.assigns.user, Message.command(text))
+    {:noreply, socket}
+  end
+end

--- a/web/channels/user_socket.ex
+++ b/web/channels/user_socket.ex
@@ -5,6 +5,7 @@ defmodule Yggdrasil.UserSocket do
 
   ## Channels
   channel "game:*", Yggdrasil.GameChannel
+  channel "player:*", Yggdrasil.PlayerChannel
 
   ## Transports
   transport :websocket, Phoenix.Transports.WebSocket

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -25,21 +25,25 @@ window.app = {
   start () {
     if (window.location.pathname !== "/client") return
 
-    socket.init()
+    socket.init((err) => {
+      if (err) return alert(err.message)
 
-    let $cmd = $("#command")
-    let $events = $("#events")
+      let $cmd = $("#command")
+      let $events = $("#events")
 
-    socket.on("event", payload => {
-      $events.append(`<li>[${Date()}] ${payload.body}`)
-    })
+      socket.on("event", payload => {
+        $events.append(`<li>[${Date()}] ${payload.message}`)
+      })
 
-    $cmd.on("keypress", e => {
-      if (e.keyCode !== 13) return
+      $cmd.on("keypress", e => {
+        if (e.keyCode !== 13) return
 
-      let cmdText = $cmd.val()
-      socket.push("user_cmd", { body: cmdText })
-      $cmd.val("")
+        let cmdText = $cmd.val()
+        socket.push("player_cmd", { text: cmdText })
+        $cmd.val("")
+      })
+
+      socket.join()
     })
   }
 }


### PR DESCRIPTION
Goal is to start a process to be the player in the game and to have it able to push messages to the user.
- [x] - start player process when user joins
- [x] - send welcome message
- [x] - terminate player process when user leaves
- [x] - do not create duplicate player process if user connects in multiple tabs
- [x] - registry process to maintain active player list and monitor player processes so the list is accurate
- [x] - message structs for sending the player things in a consistent manner
- [x] - so much testing
