### PR TITLE
Postgrex is needed as dep for ecto in yggdrasil_web

### DIFF
--- a/apps/yggdrasil_web/mix.exs
+++ b/apps/yggdrasil_web/mix.exs
@@ -23,7 +23,7 @@ defmodule YggdrasilWeb.Mixfile do
   # Type `mix help compile.app` for more information.
   def application do
     [mod: {YggdrasilWeb, []},
-     applications: [:phoenix, :phoenix_ecto, :phoenix_html,
+     applications: [:phoenix, :postgrex, :phoenix_ecto, :phoenix_html,
                     :cowboy, :logger, :gettext, :yggdrasil]]
   end
 
@@ -46,6 +46,7 @@ defmodule YggdrasilWeb.Mixfile do
      {:excoveralls, "~> 0.4.3"},
      {:ja_serializer, "~> 0.6.1"},
      {:guardian, "~> 0.9.0"},
+     {:postgrex, ">= 0.0.0"},
      {:cors_plug, "~> 0.1.4"}]
   end
 


### PR DESCRIPTION
@copenhas I think this solves your issue. When I was looking at the Yggdrasil.Web module my concerns were that postgrex adapter isn't a dependency in the web app.

It built on travis ci, and locally I was able to reproduce the error per your directions and then after this the error went away.
